### PR TITLE
Allow custom clients to be created

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -20,9 +20,14 @@ class Server {
                 \stream_set_blocking($client, false);
                 $promisor = $state->promisor;
                 $state->promisor = new amp\Deferred;
-                $promisor->succeed(new Client($client));
+                $promisor->succeed(self::createClient($client));
             }
         });
+    }
+
+    protected static function createClient($socket)
+    {
+        return new Client($socket);
     }
 
     /**

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -20,7 +20,7 @@ class Server {
                 \stream_set_blocking($client, false);
                 $promisor = $state->promisor;
                 $state->promisor = new amp\Deferred;
-                $promisor->succeed(self::createClient($client));
+                $promisor->succeed(static::createClient($client));
             }
         });
     }


### PR DESCRIPTION
This simply allows the following

```
class MyClient extends Client {}

class MyServer extends Server
{
    protected static function createClient($socket)
    {
        return new MyClient($socket);
    }
}
```

Had to be static because the `onReadable` callback is static.