### PR TITLE
Fix undefined method call in onEmptyRead()

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -285,7 +285,7 @@ class Client {
             $finalResult = isset($op->buffer[0]) ? $op->buffer : null;
             $op->promisor->succeed($finalResult);
             foreach ($state->readOperations as $op) {
-                $op->succeed();
+                $op->promisor->succeed();
             }
             $state->readOperations = [];
         }


### PR DESCRIPTION
Fixes a typo where `succeed()` is called a `StdClass` rather than the promisor instance.