### PR TITLE
Always attempt to close socket resource in close()

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -226,12 +226,13 @@ class Client {
      */
     public function close() {
         $state = $this->state;
-        if ($state->isDead) {
-            return;
-        }
         if (\is_resource($state->socket)) {
             @\fclose($state->socket);
         }
+        if ($state->isDead) {
+            return;
+        }
+
         amp\cancel($state->readWatcherId);
         amp\cancel($state->writeWatcherId);
         foreach ($state->readOperations as $op) {


### PR DESCRIPTION
We're using the amphp/socket library to create a server that accepts many connections from clients. We have been having issues with the daemon dying every few hours with a "too many open files" error. Upon further inspection with `lsof`, I noticed that client connections were lingering in a `CLOSE_WAIT` state even after `Client->close()` was called.

Looking at the close method, it will return out immediately if `isDead` is set before attempting to call `fclose` on the actual socket resource. Based on the how the class is written, it is possible for `isDead` to be set in situations where there is still a valid socket resource.

After making this change, I've not noticed a single stuck `CLOSE_WAIT` connection on my end.