### PR TITLE
Add the ability to limit DNS resolution to either A or AAAA records.

### DIFF
--- a/lib/ClientConnectContext.php
+++ b/lib/ClientConnectContext.php
@@ -2,12 +2,14 @@
 
 namespace Amp\Socket;
 
+use Amp\Dns\Record;
 use function Amp\Socket\Internal\normalizeBindToOption;
 
 final class ClientConnectContext {
     private $bindTo = null;
     private $connectTimeout = 10000;
     private $maxAttempts = 2;
+    private $typeRestriction = null;
 
     public function withBindTo(string $bindTo = null): self {
         $bindTo = normalizeBindToOption($bindTo);
@@ -50,6 +52,21 @@ final class ClientConnectContext {
 
     public function getMaxAttempts(): int {
         return $this->maxAttempts;
+    }
+
+    public function withResolveTypeRestriction(int $type): self {
+        if ($type !== null && $type !== Record::AAAA && $type !== Record::A) {
+          throw new \Error("Invalid resolver type restriction");
+        }
+
+        $clone = clone $this;
+        $clone->typeRestriction = $type;
+
+        return $clone;
+    }
+
+    public function getResolveTypeRestriction(): int {
+        return $this->typeRestriction;
     }
 
     public function toStreamContextArray(): array {

--- a/lib/ClientConnectContext.php
+++ b/lib/ClientConnectContext.php
@@ -54,7 +54,7 @@ final class ClientConnectContext {
         return $this->maxAttempts;
     }
 
-    public function withResolveTypeRestriction($type): self {
+    public function withDnsTypeRestriction($type): self {
         if ($type !== null && $type !== Record::AAAA && $type !== Record::A) {
             throw new \Error("Invalid resolver type restriction");
         }
@@ -65,7 +65,7 @@ final class ClientConnectContext {
         return $clone;
     }
 
-    public function getResolveTypeRestriction() {
+    public function getDnsTypeRestriction() {
         return $this->typeRestriction;
     }
 

--- a/lib/ClientConnectContext.php
+++ b/lib/ClientConnectContext.php
@@ -65,7 +65,7 @@ final class ClientConnectContext {
         return $clone;
     }
 
-    public function getResolveTypeRestriction(): int {
+    public function getResolveTypeRestriction(): ?int {
         return $this->typeRestriction;
     }
 

--- a/lib/ClientConnectContext.php
+++ b/lib/ClientConnectContext.php
@@ -54,7 +54,7 @@ final class ClientConnectContext {
         return $this->maxAttempts;
     }
 
-    public function withResolveTypeRestriction(int $type): self {
+    public function withResolveTypeRestriction($type): self {
         if ($type !== null && $type !== Record::AAAA && $type !== Record::A) {
           throw new \Error("Invalid resolver type restriction");
         }
@@ -65,7 +65,7 @@ final class ClientConnectContext {
         return $clone;
     }
 
-    public function getResolveTypeRestriction(): ?int {
+    public function getResolveTypeRestriction() {
         return $this->typeRestriction;
     }
 

--- a/lib/ClientConnectContext.php
+++ b/lib/ClientConnectContext.php
@@ -54,7 +54,7 @@ final class ClientConnectContext {
         return $this->maxAttempts;
     }
 
-    public function withDnsTypeRestriction($type): self {
+    public function withDnsTypeRestriction(int $type = null): self {
         if ($type !== null && $type !== Record::AAAA && $type !== Record::A) {
             throw new \Error("Invalid resolver type restriction");
         }

--- a/lib/ClientConnectContext.php
+++ b/lib/ClientConnectContext.php
@@ -56,7 +56,7 @@ final class ClientConnectContext {
 
     public function withResolveTypeRestriction($type): self {
         if ($type !== null && $type !== Record::AAAA && $type !== Record::A) {
-          throw new \Error("Invalid resolver type restriction");
+            throw new \Error("Invalid resolver type restriction");
         }
 
         $clone = clone $this;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -74,7 +74,7 @@ function connect(string $uri, ClientConnectContext $socketContext = null, Cancel
             $uris = [$uri];
         } else {
             // Host is not an IP address, so resolve the domain name.
-            $records = yield Dns\resolve($host);
+            $records = yield Dns\resolve($host, $socketContext->getResolveTypeRestriction());
             foreach ($records as $record) {
                 /** @var Dns\Record $record */
                 if ($record->getType() === Dns\Record::AAAA) {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -74,7 +74,7 @@ function connect(string $uri, ClientConnectContext $socketContext = null, Cancel
             $uris = [$uri];
         } else {
             // Host is not an IP address, so resolve the domain name.
-            $records = yield Dns\resolve($host, $socketContext->getResolveTypeRestriction());
+            $records = yield Dns\resolve($host, $socketContext->getDnsTypeRestriction());
             foreach ($records as $record) {
                 /** @var Dns\Record $record */
                 if ($record->getType() === Dns\Record::AAAA) {


### PR DESCRIPTION
I found an issue when trying to connect via an IPv4 only network to a domain (whois.donuts.co) that returns both A and AAAA records. When trying to connect, I received a `Address family for hostname not supported` fatal error (which isn't caught by the Exception catch because it's not an Exception). I tracked it down to attempts to connect using the AAAA record. The following PR adds support to the ClientConnectContext to allow you to limit resolution to just A records (or just AAAA records, of course).