### PR TITLE
Connect to ipv6 URI fails

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -71,6 +71,10 @@ function connect(string $uri, ClientConnectContext $socketContext = null, Cancel
 
         list($scheme, $host, $port) = Internal\parseUri($uri);
 
+        if (substr($host, 0, 1) === '[') {
+            $host = substr($host, 1, -1);
+        }
+        
         if ($port === 0 || @\inet_pton($host)) {
             // Host is already an IP address or file path.
             $uris = [$uri];

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -71,7 +71,7 @@ function connect(string $uri, ClientConnectContext $socketContext = null, Cancel
 
         list($scheme, $host, $port) = Internal\parseUri($uri);
 
-        if (substr($host, 0, 1) === '[') {
+        if ($host[0] === '[') {
             $host = substr($host, 1, -1);
         }
         


### PR DESCRIPTION
Example: tcp://[2a03:2880:f02d:12:face:b00c:0:3]:443
It's interpreted as a host name which then is not valid of course