### PR TITLE
Improve error message if socket isn't configured for TLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ install:
   - wget https://github.com/php-coveralls/php-coveralls/releases/download/v1.0.2/coveralls.phar
   - chmod +x coveralls.phar
 
+before_script:
+  - pushd test/tls
+  - ./regenerate.sh
+  - popd
+
 script:
     # PHPDBG segfaults on versions other than 7.0 currently
   - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then

--- a/src/ServerSocket.php
+++ b/src/ServerSocket.php
@@ -13,6 +13,15 @@ class ServerSocket extends Socket {
             return new Failure(new ClosedException("The socket has been closed"));
         }
 
+        $ctx = \stream_context_get_options($resource);
+        if (empty($ctx['ssl'])) {
+            return new Failure(new SocketException(
+                "Can't enable TLS without configuration. " .
+                "If you used Amp\\Socket\\listen(), be sure to pass a ServerTlsContext as third argument, " .
+                "otherwise set the 'ssl' context option to the PHP stream resource."
+            ));
+        }
+
         return Internal\enableCrypto($resource, [], true);
     }
 }

--- a/src/ServerSocket.php
+++ b/src/ServerSocket.php
@@ -15,7 +15,7 @@ class ServerSocket extends Socket {
 
         $ctx = \stream_context_get_options($resource);
         if (empty($ctx['ssl'])) {
-            return new Failure(new SocketException(
+            return new Failure(new CryptoException(
                 "Can't enable TLS without configuration. " .
                 "If you used Amp\\Socket\\listen(), be sure to pass a ServerTlsContext as third argument, " .
                 "otherwise set the 'ssl' context option to the PHP stream resource."

--- a/test/ClientTlsContextTest.php
+++ b/test/ClientTlsContextTest.php
@@ -271,6 +271,9 @@ class ClientTlsContextTest extends TestCase {
         $context = (new ClientTlsContext)
             ->withCaPath("/var/foobar");
 
+        $contextArray = $context->toStreamContextArray();
+        unset($contextArray['ssl']['security_level']); // present depending on OpenSSL version
+
         $this->assertSame(["ssl" => [
             "crypto_method" => $context->toStreamCryptoMethod(),
             "peer_name" => $context->getPeerName(),
@@ -282,6 +285,6 @@ class ClientTlsContextTest extends TestCase {
             "capture_peer_cert_chain" => $context->hasPeerCapturing(),
             "SNI_enabled" => $context->hasSni(),
             "capath" => $context->getCaPath(),
-        ]], $context->toStreamContextArray());
+        ]], $contextArray);
     }
 }


### PR DESCRIPTION
Previously it failed with: `PHP Fatal error: Uncaught Amp\Socket\CryptoException: Crypto negotiation failed: stream_socket_enable_crypto(): When enabling encryption you must specify the crypto type`.