### PR TITLE
Fix parseUri() for '0' hostname

### DIFF
--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -44,7 +44,7 @@ function parseUri(string $uri): array
         );
     }
 
-    if (empty($host) || empty($port)) {
+    if ($host == "" || $port == 0) {
         throw new \Error(
             "Invalid URI ({$uri}); host and port components required"
         );


### PR DESCRIPTION
If host value is '0', function will throw an error that host was not passed.