### PR TITLE
Fixed InternetAddress::fromString always failing

### DIFF
--- a/src/InternetAddress.php
+++ b/src/InternetAddress.php
@@ -15,7 +15,7 @@ final class InternetAddress implements SocketAddress
         }
 
         $ip = \substr($address, 0, $colon);
-        $port = \substr($address, $colon);
+        $port = \substr($address, $colon + 1);
 
         if (!\preg_match('/^[1-9][0-9]{0,4}$/', $port)) {
             throw new SocketException('Invalid port: ' . $port);

--- a/test/InternetAddressTest.php
+++ b/test/InternetAddressTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Amp\Socket;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see InternetAddress
+ */
+final class InternetAddressTest extends TestCase
+{
+    /**
+     * Tests that when an InternetAddress is constructed from a string with valid IP and port, no exception is thrown.
+     */
+    public function testFromString(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        InternetAddress::fromString('1.1.1.1:1');
+    }
+
+    /**
+     * Tests that when an InternetAddress is constructed from a string with an IP but no port, an exception is thrown.
+     */
+    public function testFromStringMissingPort(): void
+    {
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessage('Missing port');
+
+        InternetAddress::fromString('1.1.1.1');
+    }
+
+    /**
+     * Tests that when an InternetAddress is constructed from a string with an invalid port, an exception is thrown.
+     */
+    public function testFromStringInvalidPort(): void
+    {
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessage('Invalid port');
+
+        InternetAddress::fromString('1.1.1.1:-1');
+    }
+}


### PR DESCRIPTION
`InternetAddress::fromString` always failed to validate because it included the colon in the port. Also added a unit test for this method.