### PR TITLE
Add missing SSL context options

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Any data transmitted before `EncryptableSocket::setupTls()` completes will be tr
 Don't attempt to read from the socket or write to it manually.
 Doing so will read the raw TLS handshake data that's supposed to be read by OpenSSL.
 
+A note about self-signed certificates: No option to allow self-signed certificates is provided in `ClientTlsContext` since it is no more secure than disabling peer verification. To safely use a self-signed certificate, disable peer verification and require fingerprint verification of the certificate using `ClientTlsContext::withPeerFingerprint()`.
+
 ## Security
 
 If you discover any security related issues, please email [`me@kelunik.com`](mailto:me@kelunik.com) instead of using the issue tracker.

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "phpunit/phpunit": "^9",
         "amphp/phpunit-util": "^3",
         "amphp/php-cs-fixer-config": "^2-dev",
+        "amphp/process": "^2",
         "psalm/phar": "^4.20"
     },
     "autoload": {

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -10,15 +10,17 @@ final class Certificate
 {
     private readonly string $certFile;
     private readonly string $keyFile;
+    private readonly ?string $passphase;
 
     /**
      * @param string      $certFile Certificate file with the certificate + intermediaries.
      * @param string|null $keyFile Key file with the corresponding private key or `null` if the key is in $certFile.
      */
-    public function __construct(string $certFile, string $keyFile = null)
+    public function __construct(string $certFile, string $keyFile = null, ?string $passphrase = null)
     {
         $this->certFile = $certFile;
         $this->keyFile = $keyFile ?? $certFile;
+        $this->passphase = $passphrase;
     }
 
     public function getCertFile(): string
@@ -29,5 +31,10 @@ final class Certificate
     public function getKeyFile(): string
     {
         return $this->keyFile;
+    }
+
+    public function getPassphrase(): ?string
+    {
+        return $this->passphase;
     }
 }

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -16,7 +16,7 @@ final class Certificate
      * @param string      $certFile Certificate file with the certificate + intermediaries.
      * @param string|null $keyFile Key file with the corresponding private key or `null` if the key is in $certFile.
      */
-    public function __construct(string $certFile, string $keyFile = null, ?string $passphrase = null)
+    public function __construct(string $certFile, ?string $keyFile = null, ?string $passphrase = null)
     {
         $this->certFile = $certFile;
         $this->keyFile = $keyFile ?? $certFile;

--- a/src/ClientTlsContext.php
+++ b/src/ClientTlsContext.php
@@ -26,8 +26,6 @@ final class ClientTlsContext
 
     private bool $allowSelfSigned = false;
 
-    private bool $disableCompression = true;
-
     private ?array $peerFingerprint = null;
 
     private ?string $ciphers = null;
@@ -393,27 +391,6 @@ final class ClientTlsContext
         return $this->allowSelfSigned;
     }
 
-    public function withCompressionDisabled(): self
-    {
-        $clone = clone $this;
-        $clone->disableCompression = true;
-
-        return $clone;
-    }
-
-    public function withCompressionEnabled(): self
-    {
-        $clone = clone $this;
-        $clone->disableCompression = false;
-
-        return $clone;
-    }
-
-    public function hasCompressionEnabled(): bool
-    {
-        return !$this->disableCompression;
-    }
-
     public function withPeerFingerprint(string|array $fingerprint): self
     {
         $clone = clone $this;
@@ -502,7 +479,6 @@ final class ClientTlsContext
             'capture_peer_cert' => $this->capturePeer,
             'capture_peer_cert_chain' => $this->capturePeer,
             'SNI_enabled' => $this->sniEnabled,
-            'disable_compression' => $this->disableCompression,
             'allow_self_signed' => $this->allowSelfSigned,
         ];
 

--- a/src/ClientTlsContext.php
+++ b/src/ClientTlsContext.php
@@ -368,28 +368,31 @@ final class ClientTlsContext
         return $this->certificate;
     }
 
-    public function withPeerFingerprints(string|array $fingerprint): self
+    public function withPeerFingerprint(string $fingerprint): self
     {
-        if (\is_string($fingerprint)) {
-            $hash = match (\strlen($fingerprint)) {
-                32 => 'md5',
-                40 => 'sha1',
-                default => throw new \ValueError('String must be an MD5 or SHA1 hash'),
-            };
+        $hash = match (\strlen($fingerprint)) {
+            32 => 'md5',
+            40 => 'sha1',
+            default => throw new \ValueError('String must be an MD5 or SHA1 hash'),
+        };
 
-            $fingerprint = [$hash => $fingerprint];
-        }
+        return $this->withPeerFingerprints([$hash => $fingerprint]);
+    }
 
-        if ($fingerprint !== \array_filter($fingerprint, static fn ($value, $key) => match ($key) {
-            'md5' => \is_string($value) && \strlen($value) === 32,
-            'sha1' => \is_string($value) && \strlen($value) === 40,
-            default => false,
-        }, \ARRAY_FILTER_USE_BOTH)) {
-            throw new \ValueError('Invalid fingerprint array');
+    public function withPeerFingerprints(array $fingerprints): self
+    {
+        foreach ($fingerprints as $hash => $fingerprint) {
+            if (!\is_string($fingerprint) || !match ($hash) {
+                'md5' => \strlen($fingerprint) === 32,
+                'sha1' => \strlen($fingerprint) === 40,
+                default => false,
+            }) {
+                throw new \ValueError("Invalid fingerprint array; {$hash} is invalid");
+            }
         }
 
         $clone = clone $this;
-        $clone->peerFingerprint = $fingerprint;
+        $clone->peerFingerprint = $fingerprints;
 
         return $clone;
     }

--- a/src/ClientTlsContext.php
+++ b/src/ClientTlsContext.php
@@ -24,8 +24,6 @@ final class ClientTlsContext
 
     private int $verifyDepth = 10;
 
-    private bool $allowSelfSigned = false;
-
     private ?array $peerFingerprint = null;
 
     private ?string $ciphers = null;
@@ -370,27 +368,6 @@ final class ClientTlsContext
         return $this->certificate;
     }
 
-    public function withSelfSignedAllowed(): self
-    {
-        $clone = clone $this;
-        $clone->allowSelfSigned = true;
-
-        return $clone;
-    }
-
-    public function withSelfSignedDisallowed(): self
-    {
-        $clone = clone $this;
-        $clone->allowSelfSigned = false;
-
-        return $clone;
-    }
-
-    public function hasSelfSignedAllowed(): bool
-    {
-        return $this->allowSelfSigned;
-    }
-
     public function withPeerFingerprint(string|array $fingerprint): self
     {
         $clone = clone $this;
@@ -405,7 +382,7 @@ final class ClientTlsContext
             $fingerprint = [$hash => $fingerprint];
         }
 
-        if ($fingerprint !== \array_filter($fingerprint, fn ($value, $key) => match ($key) {
+        if ($fingerprint !== \array_filter($fingerprint, static fn ($value, $key) => match ($key) {
             'md5' => \is_string($value) && \strlen($value) === 32,
             'sha1' => \is_string($value) && \strlen($value) === 40,
             default => false,
@@ -479,7 +456,6 @@ final class ClientTlsContext
             'capture_peer_cert' => $this->capturePeer,
             'capture_peer_cert_chain' => $this->capturePeer,
             'SNI_enabled' => $this->sniEnabled,
-            'allow_self_signed' => $this->allowSelfSigned,
         ];
 
         if ($this->certificate !== null) {

--- a/src/ClientTlsContext.php
+++ b/src/ClientTlsContext.php
@@ -368,10 +368,8 @@ final class ClientTlsContext
         return $this->certificate;
     }
 
-    public function withPeerFingerprint(string|array $fingerprint): self
+    public function withPeerFingerprints(string|array $fingerprint): self
     {
-        $clone = clone $this;
-
         if (\is_string($fingerprint)) {
             $hash = match (\strlen($fingerprint)) {
                 32 => 'md5',
@@ -390,12 +388,13 @@ final class ClientTlsContext
             throw new \ValueError('Invalid fingerprint array');
         }
 
+        $clone = clone $this;
         $clone->peerFingerprint = $fingerprint;
 
         return $clone;
     }
 
-    public function withoutPeerFingerprint(): self
+    public function withoutPeerFingerprints(): self
     {
         $clone = clone $this;
         $clone->peerFingerprint = null;
@@ -403,7 +402,7 @@ final class ClientTlsContext
         return $clone;
     }
 
-    public function getPeerFingerprint(): ?array
+    public function getPeerFingerprints(): ?array
     {
         return $this->peerFingerprint;
     }
@@ -498,21 +497,12 @@ final class ClientTlsContext
      */
     public function toStreamCryptoMethod(): int
     {
-        switch ($this->minVersion) {
-            case self::TLSv1_0:
-                return self::TLSv1_0 | self::TLSv1_1 | self::TLSv1_2 | self::TLSv1_3;
-
-            case self::TLSv1_1:
-                return self::TLSv1_1 | self::TLSv1_2 | self::TLSv1_3;
-
-            case self::TLSv1_2:
-                return self::TLSv1_2 | self::TLSv1_3;
-
-            case self::TLSv1_3:
-                return self::TLSv1_3;
-
-            default:
-                throw new \RuntimeException('Unknown minimum TLS version: ' . $this->minVersion);
-        }
+        return match ($this->minVersion) {
+            self::TLSv1_0 => self::TLSv1_0 | self::TLSv1_1 | self::TLSv1_2 | self::TLSv1_3,
+            self::TLSv1_1 => self::TLSv1_1 | self::TLSv1_2 | self::TLSv1_3,
+            self::TLSv1_2 => self::TLSv1_2 | self::TLSv1_3,
+            self::TLSv1_3 => self::TLSv1_3,
+            default => throw new \Error('Unknown minimum TLS version: ' . $this->minVersion),
+        };
     }
 }

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -138,7 +138,6 @@ function setupTls($socket, array $options, ?Cancellation $cancellation): void
 
                 throw new TlsException('TLS negotiation failed: ' . $errstr);
             });
-
             $result = \stream_socket_enable_crypto($socket, enable: true);
             if ($result === false) {
                 $message = \feof($socket) ? 'Connection reset by peer' : 'Unknown error';

--- a/src/ServerTlsContext.php
+++ b/src/ServerTlsContext.php
@@ -461,14 +461,16 @@ final class ServerTlsContext
 
         if ($this->certificates) {
             $options['SNI_server_certs'] = \array_map(static function (Certificate $certificate) {
-                if ($certificate->getCertFile() === $certificate->getKeyFile()) {
-                    return $certificate->getCertFile();
-                }
-
-                return [
+                $options = [
                     'local_cert' => $certificate->getCertFile(),
                     'local_pk' => $certificate->getKeyFile(),
                 ];
+
+                if ($certificate->getPassphrase() !== null) {
+                    $options['passphrase'] = $certificate->getPassphrase();
+                }
+
+                return $options;
             }, $this->certificates);
         }
 

--- a/test/ClientTlsContextTest.php
+++ b/test/ClientTlsContextTest.php
@@ -340,19 +340,6 @@ class ClientTlsContextTest extends TestCase
         $context->withApplicationLayerProtocols([1, 2]);
     }
 
-    public function testWithSelfSigned(): void
-    {
-        $contextA = new ClientTlsContext();
-        $contextB = $contextA->withSelfSignedAllowed();
-
-        self::assertFalse($contextA->hasSelfSignedAllowed());
-        self::assertTrue($contextB->hasSelfSignedAllowed());
-
-        $contextC = $contextB->withSelfSignedDisallowed();
-
-        self::assertFalse($contextC->hasSelfSignedAllowed());
-    }
-
     public function testWithPeerFingerprint(): void
     {
         $testKey = 'test';
@@ -389,7 +376,9 @@ class ClientTlsContextTest extends TestCase
     public function testStreamContextArray(): void
     {
         $context = (new ClientTlsContext())
-            ->withCaPath('/var/foobar');
+            ->withCaPath('/var/foobar')
+            ->withoutPeerVerification()
+            ->withPeerFingerprint(\sha1('certificate-content-placeholder'));
 
         $contextArray = $context->toStreamContextArray();
         unset($contextArray['ssl']['security_level']); // present depending on OpenSSL version
@@ -405,8 +394,8 @@ class ClientTlsContextTest extends TestCase
                 'capture_peer_cert' => $context->hasPeerCapturing(),
                 'capture_peer_cert_chain' => $context->hasPeerCapturing(),
                 'SNI_enabled' => $context->hasSni(),
-                'allow_self_signed' => false,
                 'capath' => $context->getCaPath(),
+                'peer_fingerprint' => $context->getPeerFingerprint(),
             ],
         ], $contextArray);
     }

--- a/test/ClientTlsContextTest.php
+++ b/test/ClientTlsContextTest.php
@@ -345,12 +345,14 @@ class ClientTlsContextTest extends TestCase
         $testKey = 'test';
 
         $contextA = new ClientTlsContext();
-        $contextB = $contextA->withPeerFingerprints(\sha1($testKey));
-        $contextC = $contextA->withPeerFingerprints(['md5' => \md5($testKey)]);
+        $contextB = $contextA->withPeerFingerprint(\sha1($testKey));
+        $contextC = $contextB->withPeerFingerprints(['md5' => \md5($testKey)]);
+        $contextD = $contextB->withPeerFingerprint(\md5($testKey));
 
         self::assertNull($contextA->getPeerFingerprints());
         self::assertSame(['sha1' => \sha1($testKey)], $contextB->getPeerFingerprints());
         self::assertSame(['md5' => \md5($testKey)], $contextC->getPeerFingerprints());
+        self::assertSame(['md5' => \md5($testKey)], $contextD->getPeerFingerprints());
 
         self::assertNull($contextC->withoutPeerFingerprints()->getPeerFingerprints());
     }
@@ -361,7 +363,7 @@ class ClientTlsContextTest extends TestCase
         $this->expectExceptionMessage('String must be an MD5 or SHA1 hash');
 
         $context = new ClientTlsContext();
-        $context->withPeerFingerprints('invalid');
+        $context->withPeerFingerprint('invalid');
     }
 
     public function testWithInvalidFingerprintArray(): void
@@ -378,7 +380,7 @@ class ClientTlsContextTest extends TestCase
         $context = (new ClientTlsContext())
             ->withCaPath('/var/foobar')
             ->withoutPeerVerification()
-            ->withPeerFingerprints(\sha1('certificate-content-placeholder'));
+            ->withPeerFingerprint(\sha1('certificate-content-placeholder'));
 
         $contextArray = $context->toStreamContextArray();
         unset($contextArray['ssl']['security_level']); // present depending on OpenSSL version

--- a/test/ClientTlsContextTest.php
+++ b/test/ClientTlsContextTest.php
@@ -345,14 +345,14 @@ class ClientTlsContextTest extends TestCase
         $testKey = 'test';
 
         $contextA = new ClientTlsContext();
-        $contextB = $contextA->withPeerFingerprint(\sha1($testKey));
-        $contextC = $contextA->withPeerFingerprint(['md5' => \md5($testKey)]);
+        $contextB = $contextA->withPeerFingerprints(\sha1($testKey));
+        $contextC = $contextA->withPeerFingerprints(['md5' => \md5($testKey)]);
 
-        self::assertNull($contextA->getPeerFingerprint());
-        self::assertSame(['sha1' => \sha1($testKey)], $contextB->getPeerFingerprint());
-        self::assertSame(['md5' => \md5($testKey)], $contextC->getPeerFingerprint());
+        self::assertNull($contextA->getPeerFingerprints());
+        self::assertSame(['sha1' => \sha1($testKey)], $contextB->getPeerFingerprints());
+        self::assertSame(['md5' => \md5($testKey)], $contextC->getPeerFingerprints());
 
-        self::assertNull($contextC->withoutPeerFingerprint()->getPeerFingerprint());
+        self::assertNull($contextC->withoutPeerFingerprints()->getPeerFingerprints());
     }
 
     public function testWithInvalidFingerprintString(): void
@@ -361,7 +361,7 @@ class ClientTlsContextTest extends TestCase
         $this->expectExceptionMessage('String must be an MD5 or SHA1 hash');
 
         $context = new ClientTlsContext();
-        $context->withPeerFingerprint('invalid');
+        $context->withPeerFingerprints('invalid');
     }
 
     public function testWithInvalidFingerprintArray(): void
@@ -370,7 +370,7 @@ class ClientTlsContextTest extends TestCase
         $this->expectExceptionMessage('Invalid fingerprint array');
 
         $context = new ClientTlsContext();
-        $context->withPeerFingerprint(['md5' => 'invalid']);
+        $context->withPeerFingerprints(['md5' => 'invalid']);
     }
 
     public function testStreamContextArray(): void
@@ -378,7 +378,7 @@ class ClientTlsContextTest extends TestCase
         $context = (new ClientTlsContext())
             ->withCaPath('/var/foobar')
             ->withoutPeerVerification()
-            ->withPeerFingerprint(\sha1('certificate-content-placeholder'));
+            ->withPeerFingerprints(\sha1('certificate-content-placeholder'));
 
         $contextArray = $context->toStreamContextArray();
         unset($contextArray['ssl']['security_level']); // present depending on OpenSSL version
@@ -395,7 +395,7 @@ class ClientTlsContextTest extends TestCase
                 'capture_peer_cert_chain' => $context->hasPeerCapturing(),
                 'SNI_enabled' => $context->hasSni(),
                 'capath' => $context->getCaPath(),
-                'peer_fingerprint' => $context->getPeerFingerprint(),
+                'peer_fingerprint' => $context->getPeerFingerprints(),
             ],
         ], $contextArray);
     }

--- a/test/ClientTlsContextTest.php
+++ b/test/ClientTlsContextTest.php
@@ -353,19 +353,6 @@ class ClientTlsContextTest extends TestCase
         self::assertFalse($contextC->hasSelfSignedAllowed());
     }
 
-    public function testWithCompressionDisabled(): void
-    {
-        $contextA = new ClientTlsContext();
-        $contextB = $contextA->withCompressionEnabled();
-
-        self::assertFalse($contextA->hasCompressionEnabled());
-        self::assertTrue($contextB->hasCompressionEnabled());
-
-        $contextC = $contextB->withCompressionDisabled();
-
-        self::assertFalse($contextC->hasCompressionEnabled());
-    }
-
     public function testWithPeerFingerprint(): void
     {
         $testKey = 'test';
@@ -418,7 +405,6 @@ class ClientTlsContextTest extends TestCase
                 'capture_peer_cert' => $context->hasPeerCapturing(),
                 'capture_peer_cert_chain' => $context->hasPeerCapturing(),
                 'SNI_enabled' => $context->hasSni(),
-                'disable_compression' => true,
                 'allow_self_signed' => false,
                 'capath' => $context->getCaPath(),
             ],

--- a/test/ClientTlsContextTest.php
+++ b/test/ClientTlsContextTest.php
@@ -22,7 +22,7 @@ class ClientTlsContextTest extends TestCase
      */
     public function testWithMinimumVersion(int $version): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withMinimumVersion($version);
 
         self::assertSame(ClientTlsContext::TLSv1_2, $context->getMinimumVersion());
@@ -44,7 +44,7 @@ class ClientTlsContextTest extends TestCase
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('Invalid minimum version');
 
-        (new ClientTlsContext(''))->withMinimumVersion($version);
+        (new ClientTlsContext())->withMinimumVersion($version);
     }
 
     public function peerNameDataProvider(): array
@@ -60,7 +60,7 @@ class ClientTlsContextTest extends TestCase
      */
     public function testWithPeerName(string $peerName): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withPeerName($peerName);
 
         self::assertSame('', $context->getPeerName());
@@ -69,7 +69,7 @@ class ClientTlsContextTest extends TestCase
 
     public function testWithPeerVerification(): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withPeerVerification();
 
         self::assertTrue($context->hasPeerVerification());
@@ -78,7 +78,7 @@ class ClientTlsContextTest extends TestCase
 
     public function testWithoutPeerVerification(): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withoutPeerVerification();
 
         self::assertTrue($context->hasPeerVerification());
@@ -98,7 +98,7 @@ class ClientTlsContextTest extends TestCase
      */
     public function testWithCertificate(?Certificate $certificate): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withCertificate($certificate);
 
         self::assertNull($context->getCertificate());
@@ -118,7 +118,7 @@ class ClientTlsContextTest extends TestCase
      */
     public function testWithVerificationDepth(int $verifyDepth): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withVerificationDepth($verifyDepth);
 
         self::assertSame(10, $context->getVerificationDepth());
@@ -141,7 +141,7 @@ class ClientTlsContextTest extends TestCase
         $this->expectException(\Error::class);
         $this->expectExceptionMessageMatches('/Invalid verification depth (.*), must be greater than or equal to 0/');
 
-        (new ClientTlsContext(''))->withVerificationDepth($verifyDepth);
+        (new ClientTlsContext())->withVerificationDepth($verifyDepth);
     }
 
     public function ciphersDataProvider(): array
@@ -157,7 +157,7 @@ class ClientTlsContextTest extends TestCase
      */
     public function testWithCiphers(string $ciphers): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withCiphers($ciphers);
 
         self::assertSame(\OPENSSL_DEFAULT_STREAM_CIPHERS, $context->getCiphers());
@@ -177,7 +177,7 @@ class ClientTlsContextTest extends TestCase
      */
     public function testWithCaFile(?string $caFile): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withCaFile($caFile);
 
         self::assertNull($context->getCaFile());
@@ -197,7 +197,7 @@ class ClientTlsContextTest extends TestCase
      */
     public function testWithCaPath(?string $caPath): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withCaPath($caPath);
 
         self::assertNull($context->getCaPath());
@@ -206,7 +206,7 @@ class ClientTlsContextTest extends TestCase
 
     public function testWithPeerCapturing(): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withPeerCapturing();
 
         self::assertFalse($context->hasPeerCapturing());
@@ -215,7 +215,7 @@ class ClientTlsContextTest extends TestCase
 
     public function testWithoutPeerCapturing(): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withoutPeerCapturing();
 
         self::assertFalse($context->hasPeerCapturing());
@@ -224,7 +224,7 @@ class ClientTlsContextTest extends TestCase
 
     public function testWithSni(): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withSni();
 
         self::assertTrue($context->hasSni());
@@ -233,7 +233,7 @@ class ClientTlsContextTest extends TestCase
 
     public function testWithoutSni(): void
     {
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $clonedContext = $context->withoutSni();
 
         self::assertTrue($context->hasSni());
@@ -256,7 +256,7 @@ class ClientTlsContextTest extends TestCase
         $this->expectException(\Error::class);
         $this->expectExceptionMessage("Invalid security level ({$level}), must be between 0 and 5.");
 
-        (new ClientTlsContext(''))->withSecurityLevel($level);
+        (new ClientTlsContext())->withSecurityLevel($level);
     }
 
     public function testWithSecurityLevel(): void
@@ -265,7 +265,7 @@ class ClientTlsContextTest extends TestCase
             self::markTestSkipped('OpenSSL 1.1.0 required');
         }
 
-        $contextA = new ClientTlsContext('');
+        $contextA = new ClientTlsContext();
         $contextB = $contextA->withSecurityLevel(4);
 
         self::assertSame(2, $contextA->getSecurityLevel());
@@ -292,7 +292,7 @@ class ClientTlsContextTest extends TestCase
     public function testWithSecurityLevelValid(int $level): void
     {
         if (Socket\hasTlsSecurityLevelSupport()) {
-            $value = (new ClientTlsContext(''))
+            $value = (new ClientTlsContext())
                 ->withSecurityLevel($level)
                 ->getSecurityLevel();
 
@@ -301,16 +301,16 @@ class ClientTlsContextTest extends TestCase
             $this->expectException(\Error::class);
             $this->expectExceptionMessage("Can't set a security level, as PHP is compiled with OpenSSL < 1.1.0.");
 
-            (new ClientTlsContext(''))->withSecurityLevel($level);
+            (new ClientTlsContext())->withSecurityLevel($level);
         }
     }
 
     public function testWithSecurityLevelDefaultValue(): void
     {
         if (\OPENSSL_VERSION_NUMBER >= 0x10100000) {
-            self::assertSame(2, (new ClientTlsContext(''))->getSecurityLevel());
+            self::assertSame(2, (new ClientTlsContext())->getSecurityLevel());
         } else {
-            self::assertSame(0, (new ClientTlsContext(''))->getSecurityLevel());
+            self::assertSame(0, (new ClientTlsContext())->getSecurityLevel());
         }
     }
 
@@ -320,7 +320,7 @@ class ClientTlsContextTest extends TestCase
             self::markTestSkipped('OpenSSL 1.0.2 required');
         }
 
-        $contextA = new ClientTlsContext('');
+        $contextA = new ClientTlsContext();
         $contextB = $contextA->withApplicationLayerProtocols(['http/1.1', 'h2']);
 
         self::assertSame([], $contextA->getApplicationLayerProtocols());
@@ -336,13 +336,72 @@ class ClientTlsContextTest extends TestCase
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Protocol names must be strings');
 
-        $context = new ClientTlsContext('');
+        $context = new ClientTlsContext();
         $context->withApplicationLayerProtocols([1, 2]);
+    }
+
+    public function testWithSelfSigned(): void
+    {
+        $contextA = new ClientTlsContext();
+        $contextB = $contextA->withSelfSignedAllowed();
+
+        self::assertFalse($contextA->hasSelfSignedAllowed());
+        self::assertTrue($contextB->hasSelfSignedAllowed());
+
+        $contextC = $contextB->withSelfSignedDisallowed();
+
+        self::assertFalse($contextC->hasSelfSignedAllowed());
+    }
+
+    public function testWithCompressionDisabled(): void
+    {
+        $contextA = new ClientTlsContext();
+        $contextB = $contextA->withCompressionEnabled();
+
+        self::assertFalse($contextA->hasCompressionEnabled());
+        self::assertTrue($contextB->hasCompressionEnabled());
+
+        $contextC = $contextB->withCompressionDisabled();
+
+        self::assertFalse($contextC->hasCompressionEnabled());
+    }
+
+    public function testWithPeerFingerprint(): void
+    {
+        $testKey = 'test';
+
+        $contextA = new ClientTlsContext();
+        $contextB = $contextA->withPeerFingerprint(\sha1($testKey));
+        $contextC = $contextA->withPeerFingerprint(['md5' => \md5($testKey)]);
+
+        self::assertNull($contextA->getPeerFingerprint());
+        self::assertSame(['sha1' => \sha1($testKey)], $contextB->getPeerFingerprint());
+        self::assertSame(['md5' => \md5($testKey)], $contextC->getPeerFingerprint());
+
+        self::assertNull($contextC->withoutPeerFingerprint()->getPeerFingerprint());
+    }
+
+    public function testWithInvalidFingerprintString(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('String must be an MD5 or SHA1 hash');
+
+        $context = new ClientTlsContext();
+        $context->withPeerFingerprint('invalid');
+    }
+
+    public function testWithInvalidFingerprintArray(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Invalid fingerprint array');
+
+        $context = new ClientTlsContext();
+        $context->withPeerFingerprint(['md5' => 'invalid']);
     }
 
     public function testStreamContextArray(): void
     {
-        $context = (new ClientTlsContext(''))
+        $context = (new ClientTlsContext())
             ->withCaPath('/var/foobar');
 
         $contextArray = $context->toStreamContextArray();
@@ -359,6 +418,8 @@ class ClientTlsContextTest extends TestCase
                 'capture_peer_cert' => $context->hasPeerCapturing(),
                 'capture_peer_cert_chain' => $context->hasPeerCapturing(),
                 'SNI_enabled' => $context->hasSni(),
+                'disable_compression' => true,
+                'allow_self_signed' => false,
                 'capath' => $context->getCaPath(),
             ],
         ], $contextArray);

--- a/test/ConnectContextTest.php
+++ b/test/ConnectContextTest.php
@@ -147,7 +147,6 @@ class ConnectContextTest extends TestCase
                 'capture_peer_cert' => false,
                 'capture_peer_cert_chain' => false,
                 'SNI_enabled' => true,
-                'disable_compression' => true,
                 'allow_self_signed' => false,
             ],
         ];

--- a/test/ConnectContextTest.php
+++ b/test/ConnectContextTest.php
@@ -147,6 +147,8 @@ class ConnectContextTest extends TestCase
                 'capture_peer_cert' => false,
                 'capture_peer_cert_chain' => false,
                 'SNI_enabled' => true,
+                'disable_compression' => true,
+                'allow_self_signed' => false,
             ],
         ];
 

--- a/test/ConnectContextTest.php
+++ b/test/ConnectContextTest.php
@@ -147,7 +147,6 @@ class ConnectContextTest extends TestCase
                 'capture_peer_cert' => false,
                 'capture_peer_cert_chain' => false,
                 'SNI_enabled' => true,
-                'allow_self_signed' => false,
             ],
         ];
 

--- a/test/ResourceSocketServerTest.php
+++ b/test/ResourceSocketServerTest.php
@@ -163,7 +163,7 @@ class ResourceSocketServerTest extends AsyncTestCase
             $context = (new Socket\ConnectContext)->withTlsContext(
                 (new Socket\ClientTlsContext('amphp.org'))
                     ->withoutPeerVerification()
-                    ->withPeerFingerprints($this->readFingerprintFromFile(__DIR__ . '/tls/amphp.org.crt'))
+                    ->withPeerFingerprint($this->readFingerprintFromFile(__DIR__ . '/tls/amphp.org.crt'))
             );
 
             $client = Socket\connect($server->getAddress(), $context);
@@ -174,7 +174,7 @@ class ResourceSocketServerTest extends AsyncTestCase
             $context = (new Socket\ConnectContext)->withTlsContext(
                 (new Socket\ClientTlsContext('www.amphp.org'))
                     ->withoutPeerVerification()
-                    ->withPeerFingerprints($this->readFingerprintFromFile(__DIR__ . '/tls/www.amphp.org.crt'))
+                    ->withPeerFingerprint($this->readFingerprintFromFile(__DIR__ . '/tls/www.amphp.org.crt'))
             );
 
             $client = Socket\connect($server->getAddress(), $context);
@@ -204,7 +204,7 @@ class ResourceSocketServerTest extends AsyncTestCase
             $context = (new Socket\ConnectContext)->withTlsContext(
                 (new Socket\ClientTlsContext('www.amphp.org'))
                     ->withoutPeerVerification()
-                    ->withPeerFingerprints(\sha1('invalid-certificate-contents'))
+                    ->withPeerFingerprint(\sha1('invalid-certificate-contents'))
             );
 
             $client = Socket\connect($server->getAddress(), $context);

--- a/test/ResourceSocketServerTest.php
+++ b/test/ResourceSocketServerTest.php
@@ -163,7 +163,7 @@ class ResourceSocketServerTest extends AsyncTestCase
             $context = (new Socket\ConnectContext)->withTlsContext(
                 (new Socket\ClientTlsContext('amphp.org'))
                     ->withoutPeerVerification()
-                    ->withPeerFingerprint($this->readFingerprintFromFile(__DIR__ . '/tls/amphp.org.crt'))
+                    ->withPeerFingerprints($this->readFingerprintFromFile(__DIR__ . '/tls/amphp.org.crt'))
             );
 
             $client = Socket\connect($server->getAddress(), $context);
@@ -174,7 +174,7 @@ class ResourceSocketServerTest extends AsyncTestCase
             $context = (new Socket\ConnectContext)->withTlsContext(
                 (new Socket\ClientTlsContext('www.amphp.org'))
                     ->withoutPeerVerification()
-                    ->withPeerFingerprint($this->readFingerprintFromFile(__DIR__ . '/tls/www.amphp.org.crt'))
+                    ->withPeerFingerprints($this->readFingerprintFromFile(__DIR__ . '/tls/www.amphp.org.crt'))
             );
 
             $client = Socket\connect($server->getAddress(), $context);
@@ -204,7 +204,7 @@ class ResourceSocketServerTest extends AsyncTestCase
             $context = (new Socket\ConnectContext)->withTlsContext(
                 (new Socket\ClientTlsContext('www.amphp.org'))
                     ->withoutPeerVerification()
-                    ->withPeerFingerprint(\sha1('invalid-certificate-contents'))
+                    ->withPeerFingerprints(\sha1('invalid-certificate-contents'))
             );
 
             $client = Socket\connect($server->getAddress(), $context);


### PR DESCRIPTION
Adds ~~`allow_self_signed`, `disable_compression`,~~ and `peer_fingerprint` options to `ClientTLSContext` that are currently missing.

Also adds `passphrase` to `Certificate`.

Edit: Removed `disable_compression` and `allow_self_signed`.