### PR TITLE
Move TLS info method from EncryptableSocket to Socket

### DIFF
--- a/src/EncryptableSocket.php
+++ b/src/EncryptableSocket.php
@@ -9,23 +9,16 @@ interface EncryptableSocket extends Socket
     /**
      * @return void Returns when TLS is successfully set up on the socket.
      *
-     * @throws SocketException Promise fails and the socket is closed if setting up TLS fails.
+     * @throws SocketException Thrown if setting up TLS fails. Socket should be closed.
      */
     public function setupTls(?Cancellation $cancellation = null): void;
 
     /**
      * @return void Returns when TLS is successfully shutdown.
      *
-     * @throws SocketException Promise fails and the socket is closed if shutting down TLS fails.
+     * @throws SocketException Thrown if shutting down TLS fails. Socket should be closed.
      */
     public function shutdownTls(?Cancellation $cancellation = null): void;
 
     public function isTlsAvailable(): bool;
-
-    public function getTlsState(): TlsState;
-
-    /**
-     * @return TlsInfo|null The TLS (crypto) context info if TLS is enabled on the socket or null otherwise.
-     */
-    public function getTlsInfo(): ?TlsInfo;
 }

--- a/src/EncryptableSocket.php
+++ b/src/EncryptableSocket.php
@@ -21,4 +21,6 @@ interface EncryptableSocket extends Socket
     public function shutdownTls(?Cancellation $cancellation = null): void;
 
     public function isTlsAvailable(): bool;
+
+    public function getTlsState(): TlsState;
 }

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -19,8 +19,6 @@ interface Socket extends ReadableStream, WritableStream, ResourceStream
 
     public function getRemoteAddress(): SocketAddress;
 
-    public function getTlsState(): TlsState;
-
     /**
      * @return TlsInfo|null The TLS (crypto) context info if TLS is enabled on the socket or null otherwise.
      */

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -18,4 +18,11 @@ interface Socket extends ReadableStream, WritableStream, ResourceStream
     public function getLocalAddress(): SocketAddress;
 
     public function getRemoteAddress(): SocketAddress;
+
+    public function getTlsState(): TlsState;
+
+    /**
+     * @return TlsInfo|null The TLS (crypto) context info if TLS is enabled on the socket or null otherwise.
+     */
+    public function getTlsInfo(): ?TlsInfo;
 }


### PR DESCRIPTION
This allows most use-cases of sockets to use `Socket`, while only socket "owners" and factories would want to use or return `EncryptableSocket` instances.

Related to #92.