### PR TITLE
RFC: Remove EncryptableSocket

### DIFF
--- a/src/ClientTlsContext.php
+++ b/src/ClientTlsContext.php
@@ -373,6 +373,7 @@ final class ClientTlsContext
         $hash = match (\strlen($fingerprint)) {
             32 => 'md5',
             40 => 'sha1',
+            64 => 'sha256',
             default => throw new \ValueError('String must be an MD5 or SHA1 hash'),
         };
 
@@ -385,6 +386,7 @@ final class ClientTlsContext
             if (!\is_string($fingerprint) || !match ($hash) {
                 'md5' => \strlen($fingerprint) === 32,
                 'sha1' => \strlen($fingerprint) === 40,
+                'sha256' => \strlen($fingerprint) === 64,
                 default => false,
             }) {
                 throw new \ValueError("Invalid fingerprint array; {$hash} is invalid");

--- a/src/ResourceSocket.php
+++ b/src/ResourceSocket.php
@@ -5,6 +5,7 @@ namespace Amp\Socket;
 use Amp\ByteStream\ClosedException;
 use Amp\ByteStream\ReadableResourceStream;
 use Amp\ByteStream\ReadableStreamIteratorAggregate;
+use Amp\ByteStream\ResourceStream;
 use Amp\ByteStream\WritableResourceStream;
 use Amp\Cancellation;
 use Amp\ForbidCloning;
@@ -13,7 +14,7 @@ use Amp\ForbidSerialization;
 /**
  * @implements \IteratorAggregate<int, string>
  */
-final class ResourceSocket implements EncryptableSocket, \IteratorAggregate
+final class ResourceSocket implements EncryptableSocket, \IteratorAggregate, ResourceStream
 {
     use ForbidCloning;
     use ForbidSerialization;

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -7,7 +7,7 @@ use Amp\ByteStream\ResourceStream;
 use Amp\ByteStream\WritableStream;
 use Amp\Cancellation;
 
-interface Socket extends ReadableStream, WritableStream, ResourceStream
+interface Socket extends ReadableStream, WritableStream
 {
     /**
      * @param positive-int|null $limit Read at most $limit bytes from the socket. {@code null} uses an implementation

--- a/test/ResourceSocketServerTest.php
+++ b/test/ResourceSocketServerTest.php
@@ -307,10 +307,14 @@ class ResourceSocketServerTest extends AsyncTestCase
 
         $output = ByteStream\buffer($process->getStdout());
 
-        if (!\preg_match('[^SHA1 Fingerprint=(?<fingerprint>(?:[A-F0-9]{2}:){19}[A-F0-9]{2})]', $output, $matches)) {
-            $this->fail('Could not read certificate fingerprint file ' . $filename . '; openssl output: ' . $output);
+        if (\preg_match('[^SHA1 Fingerprint=(?<fingerprint>(?:[A-F0-9]{2}:){19}[A-F0-9]{2})]', $output, $matches)) {
+            return \str_replace(':', '', $matches['fingerprint']);
         }
 
-        return \str_replace(':', '', $matches['fingerprint']);
+        if (\preg_match('[^SHA256 Fingerprint=(?<fingerprint>(?:[A-F0-9]{2}:){31}[A-F0-9]{2})]', $output, $matches)) {
+            return \str_replace(':', '', $matches['fingerprint']);
+        }
+
+        $this->fail('Could not read certificate fingerprint file ' . $filename . '; openssl output: ' . $output);
     }
 }


### PR DESCRIPTION
Looking over our uses of sockets, most use `EncryptableSocket` over `Socket`. Perhaps we shouldn't differentiate between a socket and encryptable socket. Let's have just one socket interface. On sockets without TLS support, `Socket::isTlsAvailable()` can return false for implementations where TLS is not available, `setup()` and `shutdown()` can throw as the do in `ResourceSocket` if a configuration is not available, and `getTlsInfo()` would return null.