### PR TITLE
Make DatagramSocket specific for UDP

### DIFF
--- a/examples/datagram.php
+++ b/examples/datagram.php
@@ -7,7 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Amp\Socket;
 
-$datagram = Socket\bindDatagram('127.0.0.1:1337');
+$datagram = Socket\bindUdpSocket('127.0.0.1:1337');
 
 echo "Datagram active on {$datagram->getAddress()}" . PHP_EOL;
 

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -23,7 +23,8 @@ use Revolt\EventLoop;
  */
 function parseUri(string $uri): array
 {
-    if (\stripos($uri, 'unix://') === 0 || \stripos($uri, 'udg://') === 0) {
+    if (\stripos($uri, 'unix://') === 0) {
+        /** @psalm-suppress PossiblyUndefinedArrayOffset */
         [$scheme, $path] = \explode('://', $uri, 2);
         return [$scheme, \ltrim($path, '/'), 0];
     }
@@ -43,9 +44,9 @@ function parseUri(string $uri): array
     $host = $uriParts['host'] ?? '';
     $port = $uriParts['port'] ?? 0;
 
-    if (!\in_array($scheme, ['tcp', 'udp', 'unix', 'udg'], true)) {
+    if (!\in_array($scheme, ['tcp', 'udp', 'unix'], true)) {
         throw new \Error(
-            "Invalid URI scheme ($scheme); tcp, udp, unix or udg scheme expected"
+            "Invalid URI scheme ($scheme); tcp, udp, or unix scheme expected"
         );
     }
 

--- a/src/UdpSocket.php
+++ b/src/UdpSocket.php
@@ -5,13 +5,13 @@ namespace Amp\Socket;
 use Amp\Cancellation;
 use Amp\Closable;
 
-interface DatagramSocket extends Closable
+interface UdpSocket extends Closable
 {
     /**
      * @param positive-int|null $limit Read at most $limit bytes from the datagram socket. {@code null} uses an
      *     implementation defined limit.
      *
-     * @return array{SocketAddress, string}|null Returns {@code null} if the socket is closed.
+     * @return array{InternetAddress, string}|null Returns {@code null} if the socket is closed.
      *
      * @throws PendingReceiveError If a reception request is already pending.
      */
@@ -20,7 +20,7 @@ interface DatagramSocket extends Closable
     /**
      * @throws SocketException If the UDP socket closes before the data can be sent or the payload is too large.
      */
-    public function send(SocketAddress $address, string $data): void;
+    public function send(InternetAddress $address, string $data): void;
 
-    public function getAddress(): SocketAddress;
+    public function getAddress(): InternetAddress;
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -35,11 +35,11 @@ function listen(
  *
  * @throws SocketException If binding to the specified URI failed.
  */
-function bindDatagram(
+function bindUdpSocket(
     InternetAddress|string $address,
     ?BindContext $bindContext = null,
-    int $limit = ResourceDatagramSocket::DEFAULT_LIMIT
-): ResourceDatagramSocket {
+    int $limit = ResourceUdpSocket::DEFAULT_LIMIT
+): ResourceUdpSocket {
     $bindContext = $bindContext ?? new BindContext;
 
     $uri = (string) $address;
@@ -66,7 +66,7 @@ function bindDatagram(
         );
     }
 
-    return new ResourceDatagramSocket($server, $limit);
+    return new ResourceUdpSocket($server, $limit);
 }
 
 /**

--- a/test/Internal/FunctionsTest.php
+++ b/test/Internal/FunctionsTest.php
@@ -15,10 +15,6 @@ class FunctionsTest extends TestCase
                 ['unix', 'tmp/test', 0],
             ],
             [
-                'udg://test',
-                ['udg', 'test', 0],
-            ],
-            [
                 'tcp://test:1234',
                 ['tcp', 'test', 1234],
             ],
@@ -74,7 +70,7 @@ class FunctionsTest extends TestCase
     public function testParseUriInvalidScheme($uri): void
     {
         $this->expectException(\Error::class);
-        $this->expectExceptionMessageMatches('(Invalid URI scheme (.*); tcp, udp, unix or udg scheme expected)');
+        $this->expectExceptionMessageMatches('(Invalid URI scheme (.*); tcp, udp, or unix scheme expected)');
 
         Internal\parseUri($uri);
     }

--- a/test/ResourceDatagramSocketTest.php
+++ b/test/ResourceDatagramSocketTest.php
@@ -18,12 +18,12 @@ class ResourceDatagramSocketTest extends AsyncTestCase
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('Only udp scheme allowed for datagram creation');
 
-        Socket\bindDatagram("invalid://127.0.0.1:0");
+        Socket\bindUdpSocket("invalid://127.0.0.1:0");
     }
 
     public function testReceive(): void
     {
-        $endpoint = Socket\bindDatagram('127.0.0.1:0');
+        $endpoint = Socket\bindUdpSocket('127.0.0.1:0');
 
         self::assertIsResource($endpoint->getResource());
 
@@ -51,7 +51,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
 
     public function testSend(): void
     {
-        $endpoint = Socket\bindDatagram('127.0.0.1:0');
+        $endpoint = Socket\bindUdpSocket('127.0.0.1:0');
         self::assertIsResource($endpoint->getResource());
 
         $socket = Socket\connect('udp://' . $endpoint->getAddress());
@@ -90,7 +90,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
             $this->expectExceptionMessage('Could not send datagram packet: stream_socket_sendto(): Message too long');
         }
 
-        $datagramSocket = Socket\bindDatagram('127.0.0.1:0');
+        $datagramSocket = Socket\bindUdpSocket('127.0.0.1:0');
 
         $socket = Socket\connect('udp://' . $datagramSocket->getAddress());
         $socket->write('Hello!');
@@ -106,7 +106,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
 
     public function testReceiveThenClose(): void
     {
-        $endpoint = Socket\bindDatagram('127.0.0.1:0');
+        $endpoint = Socket\bindUdpSocket('127.0.0.1:0');
 
         $future = async(fn () => $endpoint->receive());
 
@@ -117,7 +117,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
 
     public function testReceiveAfterClose(): void
     {
-        $endpoint = Socket\bindDatagram('127.0.0.1:0');
+        $endpoint = Socket\bindUdpSocket('127.0.0.1:0');
 
         $endpoint->close();
 
@@ -128,7 +128,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
     {
         $this->expectException(Socket\PendingReceiveError::class);
 
-        $endpoint = Socket\bindDatagram('127.0.0.1:0');
+        $endpoint = Socket\bindUdpSocket('127.0.0.1:0');
         try {
             async(fn () => $endpoint->receive());
             async(fn () => $endpoint->receive())->await();
@@ -141,7 +141,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
     {
         $context = new Socket\BindContext();
 
-        $endpoint = Socket\bindDatagram('127.0.0.1:0', $context, 1);
+        $endpoint = Socket\bindUdpSocket('127.0.0.1:0', $context, 1);
 
         try {
             $socket = Socket\connect('udp://' . $endpoint->getAddress());
@@ -162,7 +162,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
 
     public function testLimit(): void
     {
-        $endpoint = Socket\bindDatagram('127.0.0.1:0');
+        $endpoint = Socket\bindUdpSocket('127.0.0.1:0');
 
         try {
             $socket = Socket\connect('udp://' . $endpoint->getAddress());
@@ -182,7 +182,7 @@ class ResourceDatagramSocketTest extends AsyncTestCase
 
     public function testCancelThenAccept(): void
     {
-        $datagram = Socket\bindDatagram('127.0.0.1:0');
+        $datagram = Socket\bindUdpSocket('127.0.0.1:0');
 
         try {
             $datagram->receive(new TimeoutCancellation(0.01));

--- a/test/ResourceSocketServerTest.php
+++ b/test/ResourceSocketServerTest.php
@@ -17,7 +17,7 @@ class ResourceSocketServerTest extends AsyncTestCase
     public function testListenInvalidScheme(): void
     {
         $this->expectException(\Error::class);
-        $this->expectExceptionMessage('Invalid URI scheme (invalid); tcp, udp, unix or udg scheme expected');
+        $this->expectExceptionMessage('Invalid URI scheme (invalid); tcp, udp, or unix scheme expected');
 
         Socket\listen("invalid://127.0.0.1:0");
     }


### PR DESCRIPTION
UDG needs a different interface, because there's no receiver address to pass.