### PR TITLE
Add InternetAddress::tryFromString()

### DIFF
--- a/test/InternetAddressTest.php
+++ b/test/InternetAddressTest.php
@@ -24,7 +24,7 @@ final class InternetAddressTest extends TestCase
      */
     public function testFromStringMissingPort(): void
     {
-        $this->expectException(\ValueError::class);
+        $this->expectException(SocketException::class);
         $this->expectExceptionMessage('Missing port');
 
         InternetAddress::fromString('1.1.1.1');
@@ -35,8 +35,8 @@ final class InternetAddressTest extends TestCase
      */
     public function testFromStringInvalidPort(): void
     {
-        $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('Port number must be an integer between 0 and 65535');
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessage('Invalid address');
 
         InternetAddress::fromString('1.1.1.1:-1');
     }


### PR DESCRIPTION
This PR adds `InternetAddress::tryFromString()`, which is similar to `fromString()`, accept it returns `null` instead of throwing.

Seems we were a bit inconsistent with throwing `SocketException` vs. `ValueError` for invalid portions of the address. I changed them all to `SocketException`. I think this should be fine, since we declared the constructor and `fromString` as throwing `SocketException` on an invalid address.