### PR TITLE
ServerTlsContext: allow disabling verify peer name

### DIFF
--- a/src/ClientTlsContext.php
+++ b/src/ClientTlsContext.php
@@ -22,6 +22,8 @@ final class ClientTlsContext
 
     private bool $verifyPeer = true;
 
+    private bool $verifyPeerName = true;
+
     private int $verifyDepth = 10;
 
     private ?array $peerFingerprint = null;
@@ -127,6 +129,8 @@ final class ClientTlsContext
     {
         $clone = clone $this;
         $clone->verifyPeer = false;
+        // This is for compatibility with the former behaviour:
+        $clone->verifyPeerName = false;
 
         return $clone;
     }
@@ -137,6 +141,40 @@ final class ClientTlsContext
     public function hasPeerVerification(): bool
     {
         return $this->verifyPeer;
+    }
+
+    /**
+     * Enable peer name verification, this is the default with verifyPeer enabled.
+     *
+     * @return self Cloned, modified instance.
+     */
+    public function withPeerNameVerification(): self
+    {
+        $clone = clone $this;
+        $clone->verifyPeerName = true;
+
+        return $clone;
+    }
+
+    /**
+     * Disable peer name verification.
+     *
+     * @return self Cloned, modified instance.
+     */
+    public function withoutPeerNameVerification(): self
+    {
+        $clone = clone $this;
+        $clone->verifyPeerName = false;
+
+        return $clone;
+    }
+
+    /**
+     * @return bool Whether peer verification is enabled.
+     */
+    public function hasPeerNameVerification(): bool
+    {
+        return $this->verifyPeerName;
     }
 
     /**
@@ -452,7 +490,7 @@ final class ClientTlsContext
             'crypto_method' => $this->toStreamCryptoMethod(),
             'peer_name' => $this->peerName,
             'verify_peer' => $this->verifyPeer,
-            'verify_peer_name' => $this->verifyPeer,
+            'verify_peer_name' => $this->verifyPeerName,
             'verify_depth' => $this->verifyDepth,
             'ciphers' => $this->ciphers ?? \OPENSSL_DEFAULT_STREAM_CIPHERS,
             'capture_peer_cert' => $this->capturePeer,

--- a/src/ServerTlsContext.php
+++ b/src/ServerTlsContext.php
@@ -58,6 +58,8 @@ final class ServerTlsContext
 
     private bool $verifyPeer = false;
 
+    private bool $verifyPeerName = true;
+
     private int $verifyDepth = 10;
 
     private ?string $ciphers = null;
@@ -164,6 +166,40 @@ final class ServerTlsContext
     public function hasPeerVerification(): bool
     {
         return $this->verifyPeer;
+    }
+
+    /**
+     * Enable peer name verification, this is the default with verifyPeer enabled.
+     *
+     * @return self Cloned, modified instance.
+     */
+    public function withPeerNameVerification(): self
+    {
+        $clone = clone $this;
+        $clone->verifyPeerName = true;
+
+        return $clone;
+    }
+
+    /**
+     * Disable peer name verification.
+     *
+     * @return self Cloned, modified instance.
+     */
+    public function withoutPeerNameVerification(): self
+    {
+        $clone = clone $this;
+        $clone->verifyPeerName = false;
+
+        return $clone;
+    }
+
+    /**
+     * @return bool Whether peer verification is enabled.
+     */
+    public function hasPeerNameVerification(): bool
+    {
+        return $this->verifyPeer && $this->verifyPeerName;
     }
 
     /**
@@ -437,7 +473,7 @@ final class ServerTlsContext
             'crypto_method' => $this->toStreamCryptoMethod(),
             'peer_name' => $this->peerName,
             'verify_peer' => $this->verifyPeer,
-            'verify_peer_name' => $this->verifyPeer,
+            'verify_peer_name' => $this->verifyPeer && $this->verifyPeerName,
             'verify_depth' => $this->verifyDepth,
             'ciphers' => $this->ciphers ?? \OPENSSL_DEFAULT_STREAM_CIPHERS,
             'honor_cipher_order' => true,

--- a/test/ClientTlsContextTest.php
+++ b/test/ClientTlsContextTest.php
@@ -85,6 +85,31 @@ class ClientTlsContextTest extends TestCase
         self::assertFalse($clonedContext->hasPeerVerification());
     }
 
+    public function testDefaultPeerNameVerification(): void
+    {
+        $context = new ClientTlsContext;
+        self::assertTrue($context->hasPeerNameVerification());
+    }
+
+    public function testWithoutPeerNameVerification(): void
+    {
+        $context = new ClientTlsContext;
+        $clonedContext = $context->withPeerVerification()->withoutPeerNameVerification();
+
+        self::assertTrue($clonedContext->hasPeerVerification());
+        self::assertFalse($clonedContext->hasPeerNameVerification());
+    }
+
+    public function testContextOptionsWithoutPeerNameVerification(): void
+    {
+        $context = new ClientTlsContext;
+        $clonedContext = $context->withPeerVerification()->withoutPeerNameVerification();
+        $options = $clonedContext->toStreamContextArray()['ssl'];
+
+        self::assertTrue($options['verify_peer']);
+        self::assertFalse($options['verify_peer_name']);
+    }
+
     public function certificateDataProvider(): array
     {
         return [

--- a/test/ServerTlsContextTest.php
+++ b/test/ServerTlsContextTest.php
@@ -85,6 +85,31 @@ class ServerTlsContextTest extends TestCase
         self::assertFalse($clonedContext->hasPeerVerification());
     }
 
+    public function testDefaultPeerNameVerification(): void
+    {
+        $context = new ServerTlsContext;
+        self::assertFalse($context->hasPeerNameVerification());
+    }
+
+    public function testWithoutPeerNameVerification(): void
+    {
+        $context = new ServerTlsContext;
+        $clonedContext = $context->withPeerVerification()->withoutPeerNameVerification();
+
+        self::assertTrue($clonedContext->hasPeerVerification());
+        self::assertFalse($clonedContext->hasPeerNameVerification());
+    }
+
+    public function testContextOptionsWithoutPeerNameVerification(): void
+    {
+        $context = new ServerTlsContext;
+        $clonedContext = $context->withPeerVerification()->withoutPeerNameVerification();
+        $options = $clonedContext->toStreamContextArray()['ssl'];
+
+        self::assertTrue($options['verify_peer']);
+        self::assertFalse($options['verify_peer_name']);
+    }
+
     public function verifyDepthDataProvider(): array
     {
         return [


### PR DESCRIPTION
Motivation: servers accepting connections from trusted peers do not know the expected peer name in advance. Therefore, it must be possible to accept incoming connections (validating their client certificate) without being forced to specify an expected client name.

You do not need this when using amphp/socket to run your very own public web server, but it is a requirement when running every other kind of service based on trusted client certificates (with more than one client).

This patch tries to address this, while preserving compatibility with the current behaviour.